### PR TITLE
Graceful shutdown

### DIFF
--- a/internal/server/run.go
+++ b/internal/server/run.go
@@ -6,17 +6,12 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"sync"
-	"time"
 
 	"github.com/hyqe/brigand/internal/storage"
 	"github.com/hyqe/timber"
 )
 
 func Run(ctx context.Context) {
-	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt)
-	defer cancel()
-
 	cfg, err := GetConfig()
 	if err != nil {
 		panic(err)
@@ -38,48 +33,24 @@ func Run(ctx context.Context) {
 
 	middleware := timber.NewMiddleware(jack)
 
-	httpServer := http.Server{
+	graceful(ctx, jack, &http.Server{
 		Addr:    cfg.Addr(),
 		Handler: middleware(routes),
-	}
-
-	// start the http server
-	go func() {
-		jack.Alert(fmt.Sprintf("listening on '%v'\n", httpServer.Addr))
-		err = httpServer.ListenAndServe()
-		if err != nil {
-			jack.Error(err)
-		}
-	}()
-
-	// wait for context to cancel
-	shutdown(ctx, func() {
-		jack.Alert("shutting down http server")
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer cancel()
-		httpServer.Shutdown(ctx)
 	})
 }
 
-// shutdown listens for context cancels and then calls the drain functions.
-// it is up to the individual functions to decide how to shutdown, and if
-// there should be a max timeout before forcefully shutting down.
-func shutdown(ctx context.Context, fns ...func()) {
-	<-ctx.Done()
+func graceful(
+	ctx context.Context,
+	jack timber.Jack,
+	srv *http.Server,
+) {
+	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, os.Kill)
+	defer cancel()
 
-	// shutdown all funcs at once, wait for them to finish.
-	var wg sync.WaitGroup
-	for _, fn := range fns {
-		wg.Add(1)
-		go func(fn func()) {
-			defer func() {
-				if v := recover(); v != nil {
-					fmt.Println(v)
-				}
-			}()
-			defer wg.Done()
-			fn()
-		}(fn)
-	}
-	wg.Wait()
+	jack.Alert(fmt.Sprintf("listening on '%v'\n", srv.Addr))
+	go srv.ListenAndServe()
+
+	<-ctx.Done()
+	jack.Alert("shutting down http server")
+	srv.Shutdown(context.Background())
 }

--- a/internal/server/run.go
+++ b/internal/server/run.go
@@ -4,12 +4,19 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"time"
 
 	"github.com/hyqe/brigand/internal/storage"
 	"github.com/hyqe/timber"
 )
 
 func Run(ctx context.Context) {
+	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt)
+	defer cancel()
+
 	cfg, err := GetConfig()
 	if err != nil {
 		panic(err)
@@ -31,6 +38,48 @@ func Run(ctx context.Context) {
 
 	middleware := timber.NewMiddleware(jack)
 
-	fmt.Printf("listening on '%v'\n", cfg.Addr())
-	http.ListenAndServe(cfg.Addr(), middleware(routes))
+	httpServer := http.Server{
+		Addr:    cfg.Addr(),
+		Handler: middleware(routes),
+	}
+
+	// start the http server
+	go func() {
+		jack.Alert(fmt.Sprintf("listening on '%v'\n", httpServer.Addr))
+		err = httpServer.ListenAndServe()
+		if err != nil {
+			jack.Error(err)
+		}
+	}()
+
+	// wait for context to cancel
+	shutdown(ctx, func() {
+		jack.Alert("shutting down http server")
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		defer cancel()
+		httpServer.Shutdown(ctx)
+	})
+}
+
+// shutdown listens for context cancels and then calls the drain functions.
+// it is up to the individual functions to decide how to shutdown, and if
+// there should be a max timeout before forcefully shutting down.
+func shutdown(ctx context.Context, fns ...func()) {
+	<-ctx.Done()
+
+	// shutdown all funcs at once, wait for them to finish.
+	var wg sync.WaitGroup
+	for _, fn := range fns {
+		wg.Add(1)
+		go func(fn func()) {
+			defer func() {
+				if v := recover(); v != nil {
+					fmt.Println(v)
+				}
+			}()
+			defer wg.Done()
+			fn()
+		}(fn)
+	}
+	wg.Wait()
 }

--- a/internal/server/run_test.go
+++ b/internal/server/run_test.go
@@ -1,0 +1,25 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/hyqe/timber"
+)
+
+func Test_graceful(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	jack := timber.NewJack()
+	srv := &http.Server{}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		graceful(ctx, jack, srv)
+	}()
+	cancel()
+	wg.Wait()
+}


### PR DESCRIPTION
Adds a listener for os signals: `os.Interrupt`, `os.Kill`. When signals are intercepted, shutdown the server gracefully.