### PR TITLE
add docker-compose for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,11 @@ MONGO="mongodb://localhost:27017" \
     go run main.go
 ```
 
+Run locally using Docker compose. suitable for testing only.
 
+```sh
+docker compose -f ./scripts/docker-compose-local.yaml --project-directory . up
+
+# ctrl+c to stop
+docker compose -f scripts/docker-compose-local.yaml  --project-directory . down
+```

--- a/scripts/docker-compose-local.yaml
+++ b/scripts/docker-compose-local.yaml
@@ -1,5 +1,5 @@
 services:
-  brigand:
+  web:
     build: .
     ports:
       - "8080:80"

--- a/scripts/docker-compose-local.yaml
+++ b/scripts/docker-compose-local.yaml
@@ -1,0 +1,13 @@
+services:
+  brigand:
+    build: .
+    ports:
+      - "8080:80"
+    environment:
+      - MONGO=mongodb://db
+      - LEVEL=DEBUG
+      - PORT=80
+    depends_on:
+      - db
+  db:
+    image: mongo


### PR DESCRIPTION
adds a docker compose file that deploys mongodb along side brigand, links them, and exposes Brigand on port 8080.